### PR TITLE
feat(config): add macOS configuration section to bootstrap.yaml

### DIFF
--- a/config/bootstrap.yaml
+++ b/config/bootstrap.yaml
@@ -1,16 +1,54 @@
+# ─────────────────────────────────────────────────────────────
+# FusionCloudX Bootstrap Configuration
+# ─────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────
+# WSL Configuration (Windows Subsystem for Linux)
+# ─────────────────────────────────────────────────────────────
 wsl:
   distro_name: Ubuntu
   custom_distro_name: Ubuntu-FCX
   ephemeral_mode: true
   clean_run: true
 
+# ─────────────────────────────────────────────────────────────
+# macOS Configuration
+# ─────────────────────────────────────────────────────────────
+macos:
+  # Install Homebrew if not present
+  homebrew_install: true
+
+# ─────────────────────────────────────────────────────────────
+# Network Configuration
+# ─────────────────────────────────────────────────────────────
+network:
+  # Default gateway IP (empty = auto-detect)
+  gateway: ""
+
+# ─────────────────────────────────────────────────────────────
+# Certificate Configuration
+# ─────────────────────────────────────────────────────────────
+certificates:
+  # Certificate storage paths (platform-specific)
+  root_path_linux: /etc/fusioncloudx/certs
+  root_path_macos: ""  # Empty = temp directory (certs imported to Keychain)
+
+# ─────────────────────────────────────────────────────────────
+# Git Configuration
+# ─────────────────────────────────────────────────────────────
 git:
   user_name: Your Name
   user_email: your@email.com
 
+# ─────────────────────────────────────────────────────────────
+# Windows Update Configuration (Windows only)
+# ─────────────────────────────────────────────────────────────
 windows_update:
   enabled: false
 
+# ─────────────────────────────────────────────────────────────
+# Windows Tools (WinGet packages)
+# ─────────────────────────────────────────────────────────────
 tools:
   - name: Git
     id: Git.Git

--- a/modules/1password.sh
+++ b/modules/1password.sh
@@ -1,14 +1,17 @@
 source modules/logging.sh
+source modules/platform.sh
 
 check_op_vault_access() {
     local vault="$1"
     # Quick sanity: is the token present in this shell?
     if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
-        log_warn "[1Password] OP_SERVICE_ACCOUNT_TOKEN is not set in this shell. Attempting to source /etc/profile.d/fusioncloudx.sh (if present) and retry."
-        if [[ -f /etc/profile.d/fusioncloudx.sh ]]; then
+        local profile_file
+        profile_file="$(get_profile_file)"
+        log_warn "[1Password] OP_SERVICE_ACCOUNT_TOKEN is not set in this shell. Attempting to source $profile_file (if present) and retry."
+        if [[ -f "$profile_file" ]]; then
             # shellcheck disable=SC1090
-            source /etc/profile.d/fusioncloudx.sh || true
-            log_info "[1Password] Sourced /etc/profile.d/fusioncloudx.sh"
+            source "$profile_file" || true
+            log_info "[1Password] Sourced $profile_file"
         fi
     fi
 

--- a/modules/platform.sh
+++ b/modules/platform.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------------------
+# FusionCloudX Platform Abstraction Layer
+#
+# Provides cross-platform compatibility for macOS, Linux, and WSL environments.
+# Source this module to get consistent interfaces across operating systems.
+# ------------------------------------------------------------------------------
+
+set -euo pipefail
+
+# Platform detection variables (set by detect_platform)
+export PLATFORM_OS=""
+export PLATFORM_ARCH=""
+
+# ------------------------------------------------------------------------------
+# Core Platform Detection
+# ------------------------------------------------------------------------------
+
+detect_platform() {
+    case "$(uname -s)" in
+        Darwin)
+            PLATFORM_OS="darwin"
+            ;;
+        Linux)
+            if grep -qEi "microsoft" /proc/version 2>/dev/null; then
+                PLATFORM_OS="wsl"
+            else
+                PLATFORM_OS="linux"
+            fi
+            ;;
+        *)
+            PLATFORM_OS="unknown"
+            ;;
+    esac
+
+    case "$(uname -m)" in
+        arm64|aarch64)
+            PLATFORM_ARCH="arm64"
+            ;;
+        x86_64|amd64)
+            PLATFORM_ARCH="amd64"
+            ;;
+        *)
+            PLATFORM_ARCH="unknown"
+            ;;
+    esac
+
+    export PLATFORM_OS PLATFORM_ARCH
+}
+
+# Boolean platform checks
+is_macos() {
+    [[ "$PLATFORM_OS" == "darwin" ]]
+}
+
+is_linux() {
+    [[ "$PLATFORM_OS" == "linux" ]]
+}
+
+is_wsl() {
+    [[ "$PLATFORM_OS" == "wsl" ]]
+}
+
+# Human-readable OS description
+get_os_info() {
+    case "$PLATFORM_OS" in
+        darwin)
+            sw_vers 2>/dev/null | awk -F':\t' '/ProductName|ProductVersion/ {printf "%s ", $2}' | sed 's/ $//'
+            ;;
+        wsl)
+            local distro
+            distro=$(lsb_release -d 2>/dev/null | cut -f2 || cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d'"' -f2 || echo "WSL Linux")
+            echo "$distro (WSL)"
+            ;;
+        linux)
+            lsb_release -d 2>/dev/null | cut -f2 || cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d'"' -f2 || echo "Linux"
+            ;;
+        *)
+            echo "Unknown OS"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Package Management
+# ------------------------------------------------------------------------------
+
+pkg_manager_name() {
+    case "$PLATFORM_OS" in
+        darwin)
+            echo "brew"
+            ;;
+        linux|wsl)
+            echo "apt"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
+pkg_update() {
+    case "$PLATFORM_OS" in
+        darwin)
+            brew update
+            ;;
+        linux|wsl)
+            sudo apt-get update -qq
+            ;;
+    esac
+}
+
+pkg_install() {
+    local packages=("$@")
+    case "$PLATFORM_OS" in
+        darwin)
+            brew install "${packages[@]}"
+            ;;
+        linux|wsl)
+            sudo apt-get install -y -qq "${packages[@]}"
+            ;;
+    esac
+}
+
+pkg_installed() {
+    local pkg="$1"
+    case "$PLATFORM_OS" in
+        darwin)
+            brew list "$pkg" &>/dev/null
+            ;;
+        linux|wsl)
+            dpkg -s "$pkg" &>/dev/null
+            ;;
+    esac
+}
+
+# Ensure Homebrew is installed (macOS only)
+ensure_homebrew() {
+    if ! is_macos; then
+        return 0
+    fi
+
+    if command -v brew &>/dev/null; then
+        return 0
+    fi
+
+    echo "[PLATFORM] Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Add brew to PATH for Apple Silicon
+    if [[ -f "/opt/homebrew/bin/brew" ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -f "/usr/local/bin/brew" ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Clock/NTP Functions
+# ------------------------------------------------------------------------------
+
+get_ntp_offset() {
+    local ntp_server="${1:-time.google.com}"
+
+    case "$PLATFORM_OS" in
+        darwin)
+            # macOS uses sntp
+            local output
+            output=$(sntp "$ntp_server" 2>&1 || true)
+            # Extract offset in seconds from sntp output
+            # Format: "+0.123456 +/- 0.001234 ..." or similar
+            echo "$output" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[+-]?[0-9]+\.[0-9]+$/) {print $i; exit}}' | head -1 || echo "0"
+            ;;
+        linux|wsl)
+            # Linux uses ntpdate
+            ntpdate -q "$ntp_server" 2>/dev/null | awk '/offset/ {print $10}' || echo "0"
+            ;;
+        *)
+            echo "0"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Profile/Environment Paths
+# ------------------------------------------------------------------------------
+
+get_profile_dir() {
+    case "$PLATFORM_OS" in
+        darwin)
+            echo "$HOME/.config/fusioncloudx"
+            ;;
+        linux|wsl)
+            echo "/etc/profile.d"
+            ;;
+        *)
+            echo "/tmp"
+            ;;
+    esac
+}
+
+get_profile_file() {
+    case "$PLATFORM_OS" in
+        darwin)
+            echo "$HOME/.config/fusioncloudx/env.sh"
+            ;;
+        linux|wsl)
+            echo "/etc/profile.d/fusioncloudx.sh"
+            ;;
+        *)
+            echo "/tmp/fusioncloudx.sh"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Certificate Paths
+# ------------------------------------------------------------------------------
+
+get_cert_base_path() {
+    case "$PLATFORM_OS" in
+        darwin)
+            echo "/usr/local/etc/fusioncloudx/certs"
+            ;;
+        linux|wsl)
+            echo "/etc/fusioncloudx/certs"
+            ;;
+        *)
+            echo "/tmp/fusioncloudx/certs"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# yq Download URL (architecture-aware)
+# ------------------------------------------------------------------------------
+
+get_yq_download_url() {
+    local version="${1:-v4.2.0}"
+    local platform_suffix
+
+    case "$PLATFORM_OS" in
+        darwin)
+            platform_suffix="darwin_${PLATFORM_ARCH}"
+            ;;
+        linux|wsl)
+            platform_suffix="linux_${PLATFORM_ARCH}"
+            ;;
+        *)
+            platform_suffix="linux_amd64"
+            ;;
+    esac
+
+    echo "https://github.com/mikefarah/yq/releases/download/${version}/yq_${platform_suffix}.tar.gz"
+}
+
+# ------------------------------------------------------------------------------
+# Date Arithmetic (cross-platform)
+# ------------------------------------------------------------------------------
+
+date_add_days() {
+    local days="$1"
+    local format="${2:-%Y-%m-%d}"
+
+    case "$PLATFORM_OS" in
+        darwin)
+            # BSD date syntax
+            date -v+${days}d +"$format"
+            ;;
+        linux|wsl)
+            # GNU date syntax
+            date -d "+${days} days" +"$format"
+            ;;
+        *)
+            date +"$format"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Network Functions
+# ------------------------------------------------------------------------------
+
+get_default_gateway() {
+    case "$PLATFORM_OS" in
+        darwin)
+            route -n get default 2>/dev/null | awk '/gateway:/ {print $2}'
+            ;;
+        linux|wsl)
+            ip route 2>/dev/null | awk '/default/ {print $3; exit}'
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# macOS Keychain Integration
+# ------------------------------------------------------------------------------
+
+import_ca_to_keychain() {
+    local cert_path="$1"
+    local cert_type="${2:-trustRoot}"  # trustRoot for Root CA, trustAsRoot for Intermediate
+
+    if ! is_macos; then
+        return 0  # Skip on non-macOS
+    fi
+
+    if [[ ! -f "$cert_path" ]]; then
+        echo "[PLATFORM] Certificate file not found: $cert_path" >&2
+        return 1
+    fi
+
+    echo "[PLATFORM] Importing certificate to macOS System Keychain: $cert_path"
+    sudo security add-trusted-cert -d -r "$cert_type" \
+        -k /Library/Keychains/System.keychain "$cert_path"
+    echo "[PLATFORM] Certificate trusted in macOS Keychain"
+}
+
+# ------------------------------------------------------------------------------
+# Platform-specific required commands
+# ------------------------------------------------------------------------------
+
+get_required_commands() {
+    local common_commands=(bash curl git openssl sed unzip wget)
+
+    case "$PLATFORM_OS" in
+        darwin)
+            echo "${common_commands[*]} brew"
+            ;;
+        linux|wsl)
+            echo "${common_commands[*]} apt apt-get"
+            ;;
+        *)
+            echo "${common_commands[*]}"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Package name mapping (Linux apt -> macOS brew)
+# ------------------------------------------------------------------------------
+
+map_package_name() {
+    local pkg="$1"
+
+    if ! is_macos; then
+        echo "$pkg"
+        return
+    fi
+
+    # Map Linux package names to macOS equivalents
+    case "$pkg" in
+        dnsutils)
+            echo "bind"
+            ;;
+        software-properties-common)
+            echo ""  # Not needed on macOS
+            ;;
+        gnupg)
+            echo "gnupg"  # Usually pre-installed, but available via brew
+            ;;
+        ca-certificates)
+            echo ""  # macOS uses Keychain
+            ;;
+        python3-yaml)
+            echo "pyyaml"  # pip install pyyaml
+            ;;
+        *)
+            echo "$pkg"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------------------
+# Auto-detect platform on source
+# ------------------------------------------------------------------------------
+
+detect_platform

--- a/modules/platform.sh
+++ b/modules/platform.sh
@@ -217,10 +217,38 @@ get_profile_file() {
 # Certificate Paths
 # ------------------------------------------------------------------------------
 
+# Temp directory for macOS certificate generation (created in script execution directory)
+# This avoids putting items in system-owned directories on macOS
+MACOS_CERT_TEMP_DIR=""
+
+# Initialize or get the macOS certificate temp directory
+get_macos_cert_temp_dir() {
+    if [[ -n "$MACOS_CERT_TEMP_DIR" && -d "$MACOS_CERT_TEMP_DIR" ]]; then
+        echo "$MACOS_CERT_TEMP_DIR"
+        return
+    fi
+
+    # Create temp directory in the current working directory
+    MACOS_CERT_TEMP_DIR="$(pwd)/.fusioncloudx-certs-$(date +%Y%m%d%H%M%S)"
+    mkdir -p "$MACOS_CERT_TEMP_DIR"
+    export MACOS_CERT_TEMP_DIR
+    echo "$MACOS_CERT_TEMP_DIR"
+}
+
+# Clean up macOS certificate temp directory
+cleanup_macos_cert_temp_dir() {
+    if [[ -n "$MACOS_CERT_TEMP_DIR" && -d "$MACOS_CERT_TEMP_DIR" ]]; then
+        rm -rf "$MACOS_CERT_TEMP_DIR"
+        MACOS_CERT_TEMP_DIR=""
+    fi
+}
+
 get_cert_base_path() {
     case "$PLATFORM_OS" in
         darwin)
-            echo "/usr/local/etc/fusioncloudx/certs"
+            # Use temp directory in script execution location for macOS
+            # Certs will be imported to Keychain, so we don't need persistent storage
+            get_macos_cert_temp_dir
             ;;
         linux|wsl)
             echo "/etc/fusioncloudx/certs"

--- a/phases/00-precheck/run.sh
+++ b/phases/00-precheck/run.sh
@@ -43,14 +43,6 @@ fi
 case "$PLATFORM_OS" in
     darwin)
         log_success "[PRECHECK] Running on macOS"
-        # Check for Rosetta on Apple Silicon if needed
-        if [[ "$PLATFORM_ARCH" == "arm64" ]]; then
-            if /usr/bin/pgrep -q oahd 2>/dev/null; then
-                log_info "[PRECHECK] Rosetta 2 is available"
-            else
-                log_info "[PRECHECK] Rosetta 2 not detected (may not be needed)"
-            fi
-        fi
         ;;
     wsl)
         if grep -qEi "microsoft.*WSL2" /proc/version 2>/dev/null; then

--- a/phases/00-precheck/run.sh
+++ b/phases/00-precheck/run.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Source shared logging
+# Source shared modules
 source "$(dirname "$0")/../../modules/logging.sh"
+source "$(dirname "$0")/../../modules/platform.sh"
 
 log_phase "[PRECHECK]" "start" "🧪" "Running pre-checks for FusionCloudX bootstrap..."
 
-log_info "[PRECHECK] Detected OS: $(uname -s) | $(lsb_release -d 2>/dev/null || echo 'No lsb_release')"
+log_info "[PRECHECK] Detected OS: $(uname -s) | $(get_os_info)"
+log_info "[PRECHECK] Platform: $PLATFORM_OS | Architecture: $PLATFORM_ARCH"
 
 # ─────────────────────────────────────────────────────────────
 # Shell Validation (allow Bash or Zsh)
@@ -21,33 +23,67 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────
-# Clock Skew Check
+# Clock Skew Check (platform-aware)
 # ─────────────────────────────────────────────────────────────
 ntp_server="time.google.com"
-ntp_diff=$(ntpdate -q "$ntp_server" 2>/dev/null | awk '/offset/ {print $10}' || echo 0)
+ntp_diff=$(get_ntp_offset "$ntp_server")
 
-if [[ $(echo "$ntp_diff > 2" | bc) -eq 1 ]]; then
+# Handle empty or non-numeric offset
+if [[ -z "$ntp_diff" || "$ntp_diff" == "0" ]]; then
+    log_warn "[PRECHECK] Could not determine clock offset; skipping clock skew check"
+elif [[ $(echo "${ntp_diff#-} > 2" | bc 2>/dev/null || echo 0) -eq 1 ]]; then
     log_warn "[PRECHECK] Clock skew detected. Offset: ${ntp_diff}s vs $ntp_server"
 else
     log_success "[PRECHECK] Clock skew within acceptable range: ${ntp_diff}s"
 fi
 
 # ─────────────────────────────────────────────────────────────
-# Check if running inside WSL
+# Platform Detection and Environment Check
 # ─────────────────────────────────────────────────────────────
-if grep -qEi "microsoft.*WSL2" /proc/version; then
-    log_success "[PRECHECK] Running under WSL2"
-elif grep -qEi "microsoft" /proc/version; then
-    log_warn "[PRECHECK] Detected WSL1. Compatibility may be limited."
-else
-    log_info "[PRECHECK] Not running under WSL. Assuming native Linux or container."
-fi
+case "$PLATFORM_OS" in
+    darwin)
+        log_success "[PRECHECK] Running on macOS"
+        # Check for Rosetta on Apple Silicon if needed
+        if [[ "$PLATFORM_ARCH" == "arm64" ]]; then
+            if /usr/bin/pgrep -q oahd 2>/dev/null; then
+                log_info "[PRECHECK] Rosetta 2 is available"
+            else
+                log_info "[PRECHECK] Rosetta 2 not detected (may not be needed)"
+            fi
+        fi
+        ;;
+    wsl)
+        if grep -qEi "microsoft.*WSL2" /proc/version 2>/dev/null; then
+            log_success "[PRECHECK] Running under WSL2"
+        else
+            log_warn "[PRECHECK] Detected WSL1. Compatibility may be limited."
+        fi
+        ;;
+    linux)
+        log_info "[PRECHECK] Running on native Linux"
+        ;;
+    *)
+        log_warn "[PRECHECK] Unknown platform: $PLATFORM_OS"
+        ;;
+esac
 
 # ─────────────────────────────────────────────────────────────
-# Check for required commands
+# Check for required commands (platform-specific)
 # ─────────────────────────────────────────────────────────────
+COMMON_COMMANDS=(bash curl git openssl sed unzip wget)
 
-REQUIRED_COMMANDS=(apt apt-get bash curl git openssl sed unzip wget)
+case "$PLATFORM_OS" in
+    darwin)
+        REQUIRED_COMMANDS=("${COMMON_COMMANDS[@]}" brew)
+        ;;
+    linux|wsl)
+        REQUIRED_COMMANDS=("${COMMON_COMMANDS[@]}" apt apt-get)
+        ;;
+    *)
+        REQUIRED_COMMANDS=("${COMMON_COMMANDS[@]}")
+        ;;
+esac
+
 # Note: 'yq' is handled separately because the distro/apt package is often
 # a different implementation (not mikefarah yq v4) which is incompatible
 # with the YAML expressions used by this project. We install the official
@@ -66,21 +102,39 @@ done
 
 if (( ${#missing[@]} > 0 )); then
     log_warn "[PRECHECK] Missing commands: ${missing[*]}"
-    log_info "[PRECHECK] Attempting to install missing commands with sudo: ${missing[*]}"
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq "${missing[@]}"
+    log_info "[PRECHECK] Attempting to install missing commands: ${missing[*]}"
+
+    case "$PLATFORM_OS" in
+        darwin)
+            # On macOS, ensure Homebrew first
+            if [[ " ${missing[*]} " =~ " brew " ]]; then
+                ensure_homebrew
+                # Remove brew from missing list
+                missing=("${missing[@]/brew}")
+            fi
+            # Install remaining packages via brew
+            if (( ${#missing[@]} > 0 )); then
+                brew install "${missing[@]}" 2>/dev/null || true
+            fi
+            ;;
+        linux|wsl)
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq "${missing[@]}"
+            ;;
+    esac
     log_success "[PRECHECK] All required commands installed (auto mode)."
 fi
 
-# Ensure mikefarah yq v4 is available (install official binary if missing
-# or if the installed 'yq' is a different implementation)
+# ─────────────────────────────────────────────────────────────
+# Ensure mikefarah yq v4 is available
+# ─────────────────────────────────────────────────────────────
 INSTALL_YQ=false
 if command -v yq >/dev/null 2>&1; then
     # Check for mikefarah yq v4 signature in version output
     if yq --version 2>&1 | grep -Eiq 'mikefarah|version 4'; then
         log_success "[PRECHECK] Found compatible yq: $(yq --version 2>&1 | head -n1)"
     else
-        log_warn "[PRECHECK] Found yq but it is not the expected mikefarah v4; will install official yq v4 to /usr/local/bin"
+        log_warn "[PRECHECK] Found yq but it is not the expected mikefarah v4; will install official yq v4"
         INSTALL_YQ=true
     fi
 else
@@ -89,22 +143,35 @@ else
 fi
 
 if [[ "${INSTALL_YQ:-false}" == "true" ]]; then
-    VERSION="v4.2.0"
-    PLATFORM="linux_amd64"
-    TMPDIR="$(mktemp -d)"
-    # Download and extract the compressed binary, then install it to /usr/local/bin
-    if wget -q -O - "https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_${PLATFORM}.tar.gz" | tar -xz -C "$TMPDIR"; then
-        if [[ -f "$TMPDIR"/yq_${PLATFORM} ]]; then
-            sudo mv -f "$TMPDIR"/yq_${PLATFORM} /usr/local/bin/yq
-            sudo chmod +x /usr/local/bin/yq
-            log_success "[PRECHECK] Installed official yq to /usr/local/bin/yq: $(/usr/local/bin/yq --version 2>&1 | head -n1)"
-        else
-            log_error "[PRECHECK] Download succeeded but expected binary not found in archive"
-        fi
-    else
-        log_error "[PRECHECK] Failed to download or extract official yq binary"
-    fi
-    rm -rf "$TMPDIR"
+    case "$PLATFORM_OS" in
+        darwin)
+            # On macOS, prefer Homebrew for yq
+            log_info "[PRECHECK] Installing yq via Homebrew..."
+            brew install yq
+            log_success "[PRECHECK] Installed yq via Homebrew: $(yq --version 2>&1 | head -n1)"
+            ;;
+        linux|wsl)
+            # On Linux/WSL, download binary
+            VERSION="v4.2.0"
+            YQ_URL=$(get_yq_download_url "$VERSION")
+            YQ_TMPDIR="$(mktemp -d)"
+            log_info "[PRECHECK] Downloading yq from: $YQ_URL"
+            if wget -q -O - "$YQ_URL" | tar -xz -C "$YQ_TMPDIR"; then
+                # Find the extracted binary
+                YQ_BINARY=$(find "$YQ_TMPDIR" -name 'yq_*' -type f | head -1)
+                if [[ -n "$YQ_BINARY" && -f "$YQ_BINARY" ]]; then
+                    sudo mv -f "$YQ_BINARY" /usr/local/bin/yq
+                    sudo chmod +x /usr/local/bin/yq
+                    log_success "[PRECHECK] Installed official yq to /usr/local/bin/yq: $(/usr/local/bin/yq --version 2>&1 | head -n1)"
+                else
+                    log_error "[PRECHECK] Download succeeded but expected binary not found in archive"
+                fi
+            else
+                log_error "[PRECHECK] Failed to download or extract official yq binary"
+            fi
+            rm -rf "$YQ_TMPDIR"
+            ;;
+    esac
 fi
 
 # ─────────────────────────────────────────────────────────────
@@ -126,6 +193,5 @@ else
     log_success "[PRECHECK] Running with root permissions."
 fi
 
-# Simulate success
 log_phase "00-precheck" "complete" "🧪" "Pre-checks complete"
 exit 0

--- a/phases/01-wsl-init/run.sh
+++ b/phases/01-wsl-init/run.sh
@@ -1,13 +1,28 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
 source modules/logging.sh
+source modules/platform.sh
 
+PHASE_NAME="01-wsl-init"
+
+# ─────────────────────────────────────────────────────────────
+# WSL-only phase - skip on other platforms (fallback for standalone execution)
+# Note: bootstrap.sh orchestrator handles this skip, but this provides
+# a fallback when running the phase directly
+# ─────────────────────────────────────────────────────────────
+if [[ "$PLATFORM_OS" != "wsl" ]]; then
+    log_info "[WSL INIT] Skipping: this phase only runs in WSL environment (current: $PLATFORM_OS)"
+    exit 0
+fi
+
+# ─────────────────────────────────────────────────────────────
+# WSL Initialization
+# ─────────────────────────────────────────────────────────────
 log_phase "[WSL INIT]" "start" "🐧" "Initializing WSL"
 
 if ! sudo -n true 2>/dev/null; then
-    log_error "sudo is not available without password. Please configure passwordless sudo."
+    log_error "[WSL INIT] sudo is not available without password. Please configure passwordless sudo."
     exit 1
 fi
 
@@ -15,14 +30,14 @@ fi
 mkdir -p "$HOME/fusioncloud" "$HOME/bootstrap"
 sudo mkdir -p /opt/fusioncloud
 
-log_success "Created working directories."
+log_success "[WSL INIT] Created working directories."
 
 # Sync shared assets from Windows (if applicable)
 if [[ -d /mnt/c/bootstrap-assets ]]; then
     cp -r /mnt/c/bootstrap-assets/* ~/bootstrap/
-    log_success "Copied bootstrap assets from Windows."
+    log_success "[WSL INIT] Copied bootstrap assets from Windows."
 else
-  log_warn "No /mnt/c/bootstrap-assets directory found — skipping Windows asset sync."
+    log_warn "[WSL INIT] No /mnt/c/bootstrap-assets directory found — skipping Windows asset sync."
 fi
 
-
+log_phase "$PHASE_NAME" "complete" "🐧" "WSL Init complete"

--- a/phases/02-tools/run.sh
+++ b/phases/02-tools/run.sh
@@ -1,69 +1,168 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# TODO: Should I add upgrade here? Or just ignore it since it is an ephemeral
-# distro just for disaster recovery and the real distro will be deployed to
-# VMs in ProxMox?
-
 source modules/logging.sh
+source modules/platform.sh
 source modules/notify.sh
 source modules/state.sh
 source modules/1password.sh
 
 log_phase "[TOOLS]" "start" "🔧" "Beginning essential tools installation..."
+log_info "[TOOLS] Platform: $PLATFORM_OS ($PLATFORM_ARCH)"
 
-# Refresh package index
-sudo apt-get update -y
+# ─────────────────────────────────────────────────────────────
+# Package Installation (platform-specific)
+# ─────────────────────────────────────────────────────────────
 
-# Base packages
-ESSENTIAL_PKGS=(
-    apg
-    curl
-    dnsutils
-    git
-    unzip
-    jq
-    software-properties-common
-    gnupg
-    ca-certificates
-)
+case "$PLATFORM_OS" in
+    darwin)
+        # ─────────────────────────────────────────────────────
+        # macOS: Use Homebrew
+        # ─────────────────────────────────────────────────────
+        log_info "[TOOLS] Updating Homebrew..."
+        brew update
 
-for pkg in "${ESSENTIAL_PKGS[@]}"; do
-    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
-        log_info "[APT] Installing $pkg..."
-        sudo apt-get install -y "$pkg"
-    else
-        log_info "[APT] $pkg is already installed."
-    fi
-done
+        # macOS essential packages (brew formula names)
+        ESSENTIAL_PKGS=(
+            curl
+            bind        # provides dig/nslookup (like dnsutils)
+            git
+            unzip
+            jq
+            gnupg
+        )
+        # Note: apg not available in brew, will use openssl rand fallback
+        # Note: software-properties-common and ca-certificates not needed on macOS
 
-# Optional tools
-if ! command -v yq >/dev/null 2>&1; then
-    log_info "[INFO] Installing yq from GitHub..."
-    sudo curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-    sudo chmod +x /usr/local/bin/yq
-else
-    log_info "[TOOLS] yq already installed."
-fi
+        for pkg in "${ESSENTIAL_PKGS[@]}"; do
+            if ! brew list "$pkg" &>/dev/null; then
+                log_info "[BREW] Installing $pkg..."
+                brew install "$pkg"
+            else
+                log_info "[BREW] $pkg is already installed."
+            fi
+        done
 
-# Terraform CLI
-if ! command -v terraform &>/dev/null; then
-  log_info "[TOOLS] Installing Terraform..."
-  curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/hashicorp.gpg
-  echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-  sudo apt-get update -y
-  sudo apt-get install -y terraform
-else
-  log_info "[TOOLS] Terraform already installed."
-fi
+        # yq (should already be installed by precheck, but ensure it's there)
+        if ! command -v yq >/dev/null 2>&1; then
+            log_info "[BREW] Installing yq..."
+            brew install yq
+        else
+            log_info "[TOOLS] yq already installed."
+        fi
 
-# Ansible CLI
-if ! command -v ansible &>/dev/null; then
-  log_info "[TOOLS] Installing Ansible..."
-  sudo apt-get install -y ansible
-else
-  log_info "[TOOLS] Ansible already installed."
-fi
+        # Terraform CLI via HashiCorp tap
+        if ! command -v terraform &>/dev/null; then
+            log_info "[TOOLS] Installing Terraform via Homebrew..."
+            brew tap hashicorp/tap
+            brew install hashicorp/tap/terraform
+        else
+            log_info "[TOOLS] Terraform already installed."
+        fi
+
+        # Ansible CLI
+        if ! command -v ansible &>/dev/null; then
+            log_info "[TOOLS] Installing Ansible via Homebrew..."
+            brew install ansible
+        else
+            log_info "[TOOLS] Ansible already installed."
+        fi
+
+        # 1Password CLI (cask)
+        if ! command -v op &>/dev/null; then
+            log_info "[TOOLS] Installing 1Password CLI via Homebrew..."
+            brew install --cask 1password-cli
+        else
+            log_info "[TOOLS] 1Password CLI already installed."
+        fi
+        ;;
+
+    linux|wsl)
+        # ─────────────────────────────────────────────────────
+        # Linux/WSL: Use apt
+        # ─────────────────────────────────────────────────────
+        log_info "[TOOLS] Updating apt package index..."
+        sudo apt-get update -y
+
+        # Linux essential packages
+        ESSENTIAL_PKGS=(
+            apg
+            curl
+            dnsutils
+            git
+            unzip
+            jq
+            software-properties-common
+            gnupg
+            ca-certificates
+        )
+
+        for pkg in "${ESSENTIAL_PKGS[@]}"; do
+            if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+                log_info "[APT] Installing $pkg..."
+                sudo apt-get install -y "$pkg"
+            else
+                log_info "[APT] $pkg is already installed."
+            fi
+        done
+
+        # yq (should already be installed by precheck, but ensure it's there)
+        if ! command -v yq >/dev/null 2>&1; then
+            log_info "[TOOLS] Installing yq from GitHub..."
+            YQ_URL=$(get_yq_download_url "v4.2.0")
+            sudo curl -Lo /usr/local/bin/yq "$YQ_URL"
+            sudo chmod +x /usr/local/bin/yq
+        else
+            log_info "[TOOLS] yq already installed."
+        fi
+
+        # Terraform CLI via HashiCorp apt repo
+        if ! command -v terraform &>/dev/null; then
+            log_info "[TOOLS] Installing Terraform..."
+            curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/hashicorp.gpg
+            echo "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+            sudo apt-get update -y
+            sudo apt-get install -y terraform
+        else
+            log_info "[TOOLS] Terraform already installed."
+        fi
+
+        # Ansible CLI
+        if ! command -v ansible &>/dev/null; then
+            log_info "[TOOLS] Installing Ansible..."
+            sudo apt-get install -y ansible
+        else
+            log_info "[TOOLS] Ansible already installed."
+        fi
+
+        # 1Password CLI via Debian repo
+        if ! command -v op &>/dev/null; then
+            log_info "[TOOLS] Installing 1Password CLI..."
+            curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+                sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
+                sudo tee /etc/apt/sources.list.d/1password.list
+            sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+            curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | \
+                sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
+            sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+            curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+                sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+            sudo apt update && sudo apt install -y 1password-cli
+        else
+            log_info "[TOOLS] 1Password CLI already installed."
+        fi
+        ;;
+
+    *)
+        log_error "[TOOLS] Unsupported platform: $PLATFORM_OS"
+        exit 1
+        ;;
+esac
+
+# ─────────────────────────────────────────────────────────────
+# 1Password Service Account Validation
+# ─────────────────────────────────────────────────────────────
 
 # Ensure OP_SERVICE_ACCOUNT_TOKEN is set
 if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
@@ -71,27 +170,9 @@ if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
     exit 1
 fi
 
-# 1Password CLI
-if ! command -v op &>/dev/null; then
-    log_info "[TOOLS] Installing 1Password CLI..."
-    curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
-    sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
-    sudo tee /etc/apt/sources.list.d/1password.list && \
-    sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/ && \
-    curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | \
-    sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol && \
-    sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22 && \
-    curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
-    sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg && \
-    sudo apt update && sudo apt install 1password-cli
-else
-    log_info "[TOOLS] 1Password CLI already installed."
-fi
-
 # Force op into service account mode by clearing any old session state
-rm -rf ~/.op
-unset OP_ACCOUNT # sometimes exists and interferes
+rm -rf ~/.op 2>/dev/null || true
+unset OP_ACCOUNT 2>/dev/null || true  # sometimes exists and interferes
 
 # Test 1Password connection
 check_op_vault_access "Services"

--- a/phases/03-network-checks/run.sh
+++ b/phases/03-network-checks/run.sh
@@ -2,53 +2,86 @@
 set -euo pipefail
 
 source modules/logging.sh
+source modules/platform.sh
 
 log_phase "[NETWORK CHECKS]" "start" "🌐" "Starting network checks"
-fallback=false
+log_info "[NETWORK CHECKS] Platform: $PLATFORM_OS"
 
-# Check if the internet is reachable
-if wget -q --spider https://www.google.com/generate_204; then
+# ─────────────────────────────────────────────────────────────
+# Internet Connectivity Check
+# ─────────────────────────────────────────────────────────────
+# Use curl (available on all platforms) instead of wget
+if curl -sf --max-time 10 https://www.google.com/generate_204 > /dev/null 2>&1; then
     log_success "[NETWORK CHECKS] Internet access confirmed (Google)"
 else
     log_error "[NETWORK CHECKS] Internet check failed. Please ensure you have a working internet connection."
     exit 1
 fi
 
+# ─────────────────────────────────────────────────────────────
+# DNS Resolution Check
+# ─────────────────────────────────────────────────────────────
+dns_fallback=false
+
 if command -v dig >/dev/null 2>&1; then
-    # Check DNS resolution
+    # Check DNS resolution via dig
     if dig +short google.com | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
         log_success "[NETWORK CHECKS] DNS resolution is working via dig (Google)"
     else
-        log_error "[NETWORK CHECKS] dig failed to resolve google.com — attempting nslookup..."
-        fallback=true
+        log_warn "[NETWORK CHECKS] dig failed to resolve google.com — attempting nslookup..."
+        dns_fallback=true
     fi
 else
     log_warn "[NETWORK CHECKS] dig not found — attempting nslookup..."
-    fallback=true
+    dns_fallback=true
 fi
 
-if [[ "${fallback:-false}" == true ]]; then
+if [[ "$dns_fallback" == true ]]; then
     if command -v nslookup >/dev/null 2>&1 && nslookup google.com >/dev/null 2>&1; then
         log_success "[NETWORK CHECKS] DNS resolution is working via nslookup (Google)"
     else
-        log_error "[NETWORK CHECKS] DNS resolution failed using both dig and ns lookup. Check /etc/resolv.conf for valid nameservers."
+        log_error "[NETWORK CHECKS] DNS resolution failed using both dig and nslookup."
+        case "$PLATFORM_OS" in
+            darwin)
+                log_info "[NETWORK CHECKS] Check System Preferences > Network > DNS settings"
+                ;;
+            linux|wsl)
+                log_info "[NETWORK CHECKS] Check /etc/resolv.conf for valid nameservers"
+                ;;
+        esac
         exit 1
     fi
 fi
 
-if curl -sf https://github.com > /dev/null; then
+# ─────────────────────────────────────────────────────────────
+# GitHub Connectivity Check
+# ─────────────────────────────────────────────────────────────
+if curl -sf --max-time 10 https://github.com > /dev/null; then
     log_success "[NETWORK CHECKS] GitHub is reachable over HTTPS"
 else
     log_error "[NETWORK CHECKS] GitHub is not reachable. Possible firewall or DNS issue."
     exit 1
 fi
 
-# Internal network resource check
-if ping -c 1 192.168.10.1 > /dev/null 2>&1; then
-    log_success "[NETWORK CHECKS] Gateway 192.168.10.1 is reachable"
+# ─────────────────────────────────────────────────────────────
+# Gateway Connectivity Check (non-fatal)
+# ─────────────────────────────────────────────────────────────
+# Auto-detect default gateway or use configured value
+GATEWAY_IP="${NETWORK_GATEWAY:-}"
+
+if [[ -z "$GATEWAY_IP" ]]; then
+    GATEWAY_IP=$(get_default_gateway)
+fi
+
+if [[ -n "$GATEWAY_IP" ]]; then
+    if ping -c 1 -W 2 "$GATEWAY_IP" > /dev/null 2>&1; then
+        log_success "[NETWORK CHECKS] Gateway $GATEWAY_IP is reachable"
+    else
+        # Non-fatal warning - some networks may not have traditional gateways
+        log_warn "[NETWORK CHECKS] Gateway $GATEWAY_IP is not reachable (may be expected on some networks)"
+    fi
 else
-    log_error "[NETWORK CHECKS] Gateway not reachable. Please check your network connection."
-    exit 1
+    log_warn "[NETWORK CHECKS] Could not determine default gateway - skipping gateway check"
 fi
 
 log_phase "03-network-checks" "complete" "🌐" "All network checks passed successfully"

--- a/phases/04-cert-authority-bootstrap/run.sh
+++ b/phases/04-cert-authority-bootstrap/run.sh
@@ -5,11 +5,14 @@ PHASE_NAME="04-cert-authority-bootstrap"
 PHASE_DESC="Root CA and SSL generation"
 
 source modules/logging.sh
+source modules/platform.sh
 source modules/notify.sh
 source modules/state.sh
 source modules/1password.sh
 
 log_phase "$PHASE_NAME" "start" "🔑" "$PHASE_DESC"
+log_info "[CERT] Platform: $PLATFORM_OS ($PLATFORM_ARCH)"
+
 if ! command -v op &> /dev/null; then
     log_error "[CERT] 1Password CLI (op) is not installed. Please install it before running this phase."
     exit 1
@@ -25,13 +28,18 @@ CA_ITEM_NAME="${ORGANIZATION} Root CA Bundle"
 INT_CA_ITEM_NAME="${ORGANIZATION} Intermediate CA Bundle"
 KEY_ITEM_NAME="${CA_ITEM_NAME} Key"
 
+# ─────────────────────────────────────────────────────────────
 # Define directories for storing certificates and keys
-CERT_ROOT="/etc/fusioncloudx/certs"
+# Platform-aware: macOS uses temp dir, Linux uses system dir
+# ─────────────────────────────────────────────────────────────
+CERT_ROOT="$(get_cert_base_path)"
 CA_DIR="$CERT_ROOT/ca"
 INT_DIR="$CERT_ROOT/intermediate"
 CERTS_DIR="$CERT_ROOT/issued"
 PRIVATE_DIR="$CERT_ROOT/private"
 EXTFILE="$CERT_ROOT/extfile.cnf"
+
+log_info "[CERT] Certificate root directory: $CERT_ROOT"
 
 # File paths for CA and server certificates
 ROOT_CA_CERT="$PRIVATE_DIR/root-ca.pem"
@@ -48,13 +56,71 @@ SUBJ="/C=US/ST=State/L=City/O=FusionCloudX/OU=DevOps/CN=*.fusioncloudx.home"
 SAN_DNS="DNS:fusioncloudx.home,DNS:*.fusioncloudx.home"
 SAN_IP="IP:192.168.10.1,IP:192.168.40.49,IP:192.168.40.50,IP:192.168.40.137,IP:192.168.40.93"
 
-# Create required directories if they don't exist
-for dir in "$CA_DIR" "$INT_DIR" "$CERTS_DIR" "$PRIVATE_DIR"; do
+# ─────────────────────────────────────────────────────────────
+# Helper function for generating random passphrase
+# Uses apg on Linux, openssl on macOS (apg not in Homebrew)
+# ─────────────────────────────────────────────────────────────
+generate_passphrase() {
+    if command -v apg &>/dev/null; then
+        apg -n 1 -m 32 -x 32 -M CLSN -c 1
+    else
+        # Fallback: openssl rand (available on all platforms)
+        openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────
+# Create required directories
+# macOS: temp dir owned by user, no sudo needed
+# Linux: system dir, sudo required
+# ─────────────────────────────────────────────────────────────
+create_cert_dir() {
+    local dir="$1"
     if [[ ! -d "$dir" ]]; then
         log_info "[CERT] Creating directory: $dir"
-        sudo mkdir -p "$dir"
+        if is_macos; then
+            mkdir -p "$dir"
+        else
+            sudo mkdir -p "$dir"
+        fi
     fi
+}
+
+for dir in "$CA_DIR" "$INT_DIR" "$CERTS_DIR" "$PRIVATE_DIR"; do
+    create_cert_dir "$dir"
 done
+
+# ─────────────────────────────────────────────────────────────
+# Helper for running openssl commands (with/without sudo)
+# ─────────────────────────────────────────────────────────────
+run_openssl() {
+    if is_macos; then
+        openssl "$@"
+    else
+        sudo openssl "$@"
+    fi
+}
+
+# Helper for writing files
+write_file() {
+    local content="$1"
+    local dest="$2"
+    if is_macos; then
+        echo "$content" > "$dest"
+    else
+        echo "$content" | sudo tee "$dest" > /dev/null
+    fi
+}
+
+append_file() {
+    local content="$1"
+    local dest="$2"
+    if is_macos; then
+        echo "$content" >> "$dest"
+    else
+        echo "$content" | sudo tee -a "$dest" > /dev/null
+    fi
+}
 
 # TODO: Consider cert rotation if certs exist and are nearing expiry. or forced rotation via env var.
 
@@ -65,7 +131,8 @@ else
     log_info "[CERT][1Password] No existing Root CA found in 1Password vault."
 
     # Generate a new Root CA passphrase and store it in 1Password
-    if CA_PASS_JSON=$(op item create "Certificate Authority.CA Passphrase[concealed]=$(apg -n 1 -m 32 -x 32 -M CLSN -c 1)" --vault "$VAULT_NAME" --template "templates/1password/ca-bundle-template.json" --format json); then
+    PASSPHRASE=$(generate_passphrase)
+    if CA_PASS_JSON=$(op item create "Certificate Authority.CA Passphrase[concealed]=$PASSPHRASE" --vault "$VAULT_NAME" --template "templates/1password/ca-bundle-template.json" --format json); then
         CA_PASS=$(echo "$CA_PASS_JSON" | jq -r '.fields[] | select(.id=="ca_passphrase") | .value')
         log_info "[CERT][1Password] New Root CA passphrase generated and stored in 1Password."
     else
@@ -76,14 +143,15 @@ else
     # Generate Root CA
     if [[ ! -f "$ROOT_CA_KEY" || ! -f "$ROOT_CA_CERT" ]]; then
         log_info "[CERT] Generating Root CA..."
-        sudo openssl genrsa -aes256 -passout pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")" -out "$ROOT_CA_KEY" 4096
-        sudo openssl req -x509 -sha256 -days 3650 -key "$ROOT_CA_KEY" -subj "$SUBJ" -out "$ROOT_CA_CERT" -passin pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")"
+        run_openssl genrsa -aes256 -passout pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")" -out "$ROOT_CA_KEY" 4096
+        run_openssl req -x509 -sha256 -days 3650 -key "$ROOT_CA_KEY" -subj "$SUBJ" -out "$ROOT_CA_CERT" -passin pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")"
         log_success "[CERT] Root CA generated successfully: $ROOT_CA_CERT"
         sleep 2
     fi
 
     # Generate a new Intermediate CA passphrase and store it in 1Password
-    if INT_CA_PASS_JSON=$(op item create --title="FusionCloudX Intermediate CA Bundle" "Certificate Authority.CA Passphrase[concealed]=$(apg -n 1 -m 32 -x 32 -M CLSN -c 1)" --vault "$VAULT_NAME" --template "templates/1password/ca-bundle-template.json" --format json); then
+    INT_PASSPHRASE=$(generate_passphrase)
+    if INT_CA_PASS_JSON=$(op item create --title="FusionCloudX Intermediate CA Bundle" "Certificate Authority.CA Passphrase[concealed]=$INT_PASSPHRASE" --vault "$VAULT_NAME" --template "templates/1password/ca-bundle-template.json" --format json); then
         INT_CA_PASS=$(echo "$INT_CA_PASS_JSON" | jq -r '.fields[] | select(.id=="ca_passphrase") | .value')
         log_info "[CERT][1Password] New Intermediate CA passphrase generated and stored in 1Password."
     else
@@ -94,11 +162,11 @@ else
     # Generate Intermediate CA
     if [[ ! -f "$INT_CA_KEY" || ! -f "$INT_CA_CERT" ]]; then
         log_info "[CERT] Generating Intermediate CA..."
-        sudo openssl genrsa -aes256 -passout pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")" -out "$INT_CA_KEY" 4096
+        run_openssl genrsa -aes256 -passout pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")" -out "$INT_CA_KEY" 4096
         log_info "[CERT] Generating Intermediate CA CSR..."
-        sudo openssl req -new -sha256 -key "$INT_CA_KEY" -subj "$SUBJ" -out "$INT_DIR/intermediate-ca.csr" -passin pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")"
+        run_openssl req -new -sha256 -key "$INT_CA_KEY" -subj "$SUBJ" -out "$INT_DIR/intermediate-ca.csr" -passin pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")"
         log_info "[CERT] Signing Intermediate CA with Root CA..."
-        sudo openssl x509 -req -sha256 -days 3650 -in "$INT_DIR/intermediate-ca.csr" -CA "$ROOT_CA_CERT" -CAkey "$ROOT_CA_KEY" -CAcreateserial -out "$INT_CA_CERT" --passin pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")"
+        run_openssl x509 -req -sha256 -days 3650 -in "$INT_DIR/intermediate-ca.csr" -CA "$ROOT_CA_CERT" -CAkey "$ROOT_CA_KEY" -CAcreateserial -out "$INT_CA_CERT" -passin pass:"$(op read "op://$VAULT_NAME/$CA_ITEM_NAME/CA passphrase")"
         log_info "[CERT] Intermediate CA signed successfully: $INT_CA_CERT"
         log_success "[CERT] Intermediate CA generated successfully: $INT_CA_CERT"
     fi
@@ -106,46 +174,55 @@ else
     # Generate server key and CSR
     if [[ ! -f "$CERT_KEY" || ! -f "$CERT_CSR" ]]; then
         log_info "[CERT] Generating server key and CSR..."
-        sudo openssl genrsa -out "$CERT_KEY" 4096
-        sudo openssl req -new -sha256 -key "$CERT_KEY" -subj "$SUBJ" -out "$CERT_CSR"
+        run_openssl genrsa -out "$CERT_KEY" 4096
+        run_openssl req -new -sha256 -key "$CERT_KEY" -subj "$SUBJ" -out "$CERT_CSR"
         log_success "[CERT] Server key and CSR generated successfully."
     fi
 
-    # Write extnensions file for SAN
+    # Write extensions file for SAN
     if [[ ! -f "$EXTFILE" ]]; then
         log_info "[CERT] Writing extensions file for SAN..."
-        echo "subjectAltName=$SAN_DNS,$SAN_IP" | sudo tee "$EXTFILE" > /dev/null
-        echo "extendedKeyUsage=serverAuth" | sudo tee -a "$EXTFILE" > /dev/null
+        write_file "subjectAltName=$SAN_DNS,$SAN_IP" "$EXTFILE"
+        append_file "extendedKeyUsage=serverAuth" "$EXTFILE"
         log_success "[CERT] Extensions file written successfully: $EXTFILE"
-        sudo touch "$EXTFILE"
     fi
-    
+
     # Sign server cert with Intermediate CA
     if [[ ! -f "$CERT_PEM" ]]; then
         log_info "[CERT] Signing server certificate with Intermediate CA..."
-        sudo openssl x509 -req -sha256 -days 3650 -in "$CERT_CSR" -CA "$INT_CA_CERT" -CAkey "$INT_CA_KEY" -CAcreateserial -out "$CERT_PEM" -extfile "$EXTFILE" --passin pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")"
+        run_openssl x509 -req -sha256 -days 3650 -in "$CERT_CSR" -CA "$INT_CA_CERT" -CAkey "$INT_CA_KEY" -CAcreateserial -out "$CERT_PEM" -extfile "$EXTFILE" -passin pass:"$(op read "op://$VAULT_NAME/$INT_CA_ITEM_NAME/CA passphrase")"
         log_success "[CERT] Server certificate signed successfully: $CERT_PEM"
     fi
 
     # Build fullchain.pem
     if [[ ! -f "$FULLCHAIN_PEM" ]]; then
         log_info "[CERT] Building fullchain.pem..."
-        sudo cat "$CERT_PEM" "$INT_CA_CERT" "$ROOT_CA_CERT" | sudo tee "$FULLCHAIN_PEM" > /dev/null
+        if is_macos; then
+            cat "$CERT_PEM" "$INT_CA_CERT" "$ROOT_CA_CERT" > "$FULLCHAIN_PEM"
+        else
+            sudo cat "$CERT_PEM" "$INT_CA_CERT" "$ROOT_CA_CERT" | sudo tee "$FULLCHAIN_PEM" > /dev/null
+        fi
         log_success "[CERT] Fullchain.pem created successfully: $FULLCHAIN_PEM"
     fi
 
     # Set file permissions
     log_info "[CERT] Setting file permissions..."
-    sudo chmod 644 "$ROOT_CA_CERT" "$INT_CA_CERT" "$CERT_PEM" "$FULLCHAIN_PEM" "$ROOT_CA_KEY" "$INT_CA_KEY" "$CERT_KEY"
+    if is_macos; then
+        chmod 644 "$ROOT_CA_CERT" "$INT_CA_CERT" "$CERT_PEM" "$FULLCHAIN_PEM" "$ROOT_CA_KEY" "$INT_CA_KEY" "$CERT_KEY"
+    else
+        sudo chmod 644 "$ROOT_CA_CERT" "$INT_CA_CERT" "$CERT_PEM" "$FULLCHAIN_PEM" "$ROOT_CA_KEY" "$INT_CA_KEY" "$CERT_KEY"
+    fi
     log_success "[CERT] File permissions set successfully."
 
     # Prepare common metadata right before using it to ensure variables are expanded
+    # Use date_add_days() for cross-platform date arithmetic
+    CERT_EXPIRY=$(date_add_days 3650 "%Y-%m-%d")
     METADATA_ARGS=(
         "Metadata.Subject CN=${SUBJ}"
         "Metadata.SAN DNS=${SAN_DNS}"
         "Metadata.SAN IP=${SAN_IP}"
-        "Metadata.Server Cert Expiry=$(date -d '+3650 days' +%Y-%m-%d)"
-        "Metadata.CA Cert Expiry=$(date -d '+3650 days' +%Y-%m-%d)"
+        "Metadata.Server Cert Expiry=${CERT_EXPIRY}"
+        "Metadata.CA Cert Expiry=${CERT_EXPIRY}"
     )
 
     log_info "[CERT][1Password] Common metadata prepared for 1Password items: ${METADATA_ARGS[*]}"
@@ -155,7 +232,7 @@ else
         "Files.root-ca\\.pem[file]=$ROOT_CA_CERT" \
         "Files.root-ca-key\\.pem[file]=$ROOT_CA_KEY" \
         "${METADATA_ARGS[@]}"; then
-        
+
         log_error "[CERT][1Password] Failed to update Root CA item in 1Password."
         exit 1
     fi
@@ -169,14 +246,37 @@ else
         "${METADATA_ARGS[@]}"; then
 
         log_error "[CERT][1Password] Failed to update Intermediate CA item in 1Password."
-        log_success "[CERT] Server certificate signed successfully: $CERT_PEM"
         exit 1
     fi
-fi
 
+    # ─────────────────────────────────────────────────────────────
+    # macOS Keychain Integration
+    # Import Root CA and Intermediate CA to System Keychain for trust
+    # ─────────────────────────────────────────────────────────────
+    if is_macos; then
+        log_info "[CERT] Importing certificates to macOS System Keychain..."
+
+        # Import Root CA (trustRoot = full trust as root CA)
+        if import_ca_to_keychain "$ROOT_CA_CERT" "trustRoot"; then
+            log_success "[CERT] Root CA imported to macOS Keychain"
+        else
+            log_warn "[CERT] Failed to import Root CA to Keychain (may require admin password)"
+        fi
+
+        # Import Intermediate CA (trustAsRoot = trust as intermediate)
+        if import_ca_to_keychain "$INT_CA_CERT" "trustAsRoot"; then
+            log_success "[CERT] Intermediate CA imported to macOS Keychain"
+        else
+            log_warn "[CERT] Failed to import Intermediate CA to Keychain (may require admin password)"
+        fi
+
+        log_info "[CERT] Certificates are now trusted system-wide on this Mac"
+        log_info "[CERT] Temp certificate directory: $CERT_ROOT"
+        log_info "[CERT] Run 'cleanup_macos_cert_temp_dir' to remove temp files after verification"
+    fi
+fi
 
 # TODO: Add logic for Intermediate CA, fullchain generation, and distribution to UDM Pro, UNAS Pro, etc.
 # TODO: Export trusted certs to NFS for client installation (Windows/iOS/macOS)
 # TODO: Auto import into Windows Trusted Root CA store when we jump back to Windows. Let ansible handle this?
 log_phase "$PHASE_NAME" "complete" "🔑" "$PHASE_DESC"
-


### PR DESCRIPTION
## Summary
- Add macOS-specific configuration options to bootstrap.yaml
- Reorganize config with clear section comments

## Dependencies
- Requires PR #13, #14, #15, #16, #17, #18, #19 to be merged first

## Changes

### New Configuration Sections

```yaml
macos:
  homebrew_install: true

network:
  gateway: ""  # Empty = auto-detect

certificates:
  root_path_linux: /etc/fusioncloudx/certs
  root_path_macos: ""  # Empty = temp directory (certs imported to Keychain)
```

### Notes
- Rosetta 2 check removed - not needed as all tools have native ARM64 builds
- Network gateway auto-detection works on all platforms
- macOS certificates use temp directory + Keychain import (no persistent storage needed)

## Test plan
- [x] Verified on macOS Tahoe 26.2 (Mac Mini M4 Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)